### PR TITLE
fix: remove unique index on name and site

### DIFF
--- a/cwm-data/src/main/java/org/cast/cwm/data/Period.java
+++ b/cwm-data/src/main/java/org/cast/cwm/data/Period.java
@@ -59,11 +59,9 @@ public class Period extends PersistedObject implements Comparable<Period> {
 	@Setter(AccessLevel.NONE)
 	private Long id;
 
-	@NaturalId(mutable=true)
 	@ManyToOne(optional=false)
 	private Site site;
 
-	@NaturalId(mutable=true)
 	private String name;
 
 	/**


### PR DESCRIPTION
since via LTI periods are allowed to be created with identical name